### PR TITLE
Add session heartbeat and monitoring system

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -199,23 +199,32 @@ This allows different projects to POST to different orchestrator instances.
 
 ## API Endpoints
 
-### Sessions
+### Sessions (API Key Authentication Required)
+All session endpoints require API key authentication via the `x-api-key` header:
 - `POST /api/sessions` - Create new session
 - `GET /api/sessions` - List all sessions
 - `GET /api/sessions/:id` - Get session details
 - `PATCH /api/sessions/:id` - Update session (status, claude_session_id, metadata)
-- `POST /api/sessions/:id/heartbeat` - Signal session liveness
+- `POST /api/sessions/:id/heartbeat` - Signal session liveness (API key auth)
 
-### Messages
+### Messages (API Key Authentication Required)
 - `GET /api/sessions/:id/messages` - Get conversation history
 - `POST /api/sessions/:id/messages` - Add message (for dashboard intervention)
 
-### Command Logs
+### Command Logs (API Key Authentication Required)
 - `GET /api/sessions/:id/logs?limit=50` - Get tool execution history
 
-### Hooks (Called by Claude Code)
+### Hooks (Hook Secret Authentication)
+Hook endpoints use a separate authentication mechanism via the `x-hook-secret` header.
+These are called by Claude Code hook scripts:
 - `POST /api/hooks/tool-complete` - Log tool execution
 - `POST /api/hooks/notification` - Log Claude Code notification
+- `POST /api/hooks/sessions/:id/heartbeat` - Signal session liveness (hook auth)
+
+**Authentication Configuration:**
+- API key: Set `ORCHESTRATOR_API_KEY` environment variable in hook scripts
+- Hook secret: Set `HOOK_SECRET` environment variable (must match server's `HOOK_SECRET`)
+- Hook scripts should include error handling for 401/403 responses to surface auth failures
 
 ### Session Status Values
 - `active` - Session is running and receiving heartbeats

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,6 +75,10 @@ For the monitoring dashboard, REST polling is sufficient because:
   - `POST /api/hooks/notification`: Fires on Claude Code status messages
 - **`src/services/workspace.ts`**: Workspace management
   - GitHub cloning, local folders, git worktrees, E2B sandboxes
+- **`src/services/sessionMonitor.ts`**: Session health monitoring
+  - Stale session detection (no heartbeat for 2+ minutes)
+  - Process liveness checks via PID tracking
+  - Automatic status transitions to 'stale' or 'crashed'
 - **`src/db/`**: Database schema and query helpers
 
 ### Dashboard (`/dashboard`)
@@ -144,6 +148,12 @@ N8N_WEBHOOK_BASE=http://localhost:5678
 # Optional: Slack integration
 SLACK_BOT_TOKEN=xoxb-your-token
 SLACK_SIGNING_SECRET=your-secret
+
+# Session Monitor Configuration
+ENABLE_SESSION_MONITOR=true
+SESSION_STALE_TIMEOUT_MINUTES=2
+SESSION_STALE_CRON=* * * * *
+SESSION_LIVENESS_CRON=*/5 * * * *
 ```
 
 ## Claude Code Hook Configuration
@@ -193,7 +203,8 @@ This allows different projects to POST to different orchestrator instances.
 - `POST /api/sessions` - Create new session
 - `GET /api/sessions` - List all sessions
 - `GET /api/sessions/:id` - Get session details
-- `PATCH /api/sessions/:id` - Update session (status, claude_session_id)
+- `PATCH /api/sessions/:id` - Update session (status, claude_session_id, metadata)
+- `POST /api/sessions/:id/heartbeat` - Signal session liveness
 
 ### Messages
 - `GET /api/sessions/:id/messages` - Get conversation history
@@ -205,6 +216,14 @@ This allows different projects to POST to different orchestrator instances.
 ### Hooks (Called by Claude Code)
 - `POST /api/hooks/tool-complete` - Log tool execution
 - `POST /api/hooks/notification` - Log Claude Code notification
+
+### Session Status Values
+- `active` - Session is running and receiving heartbeats
+- `paused` - Session is paused
+- `completed` - Session finished successfully
+- `error` - Session encountered an error
+- `stale` - Session stopped sending heartbeats (detected by session monitor)
+- `crashed` - Claude Code process died (detected by PID liveness check)
 
 ## Development Workflow
 

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -513,8 +513,13 @@ POST /api/sessions/:id/heartbeat
 
 **Implementation Notes**:
 - Updates both `updated_at` and stores `lastHeartbeat` timestamp in session metadata
+- The heartbeat endpoint **must** set `metadata.lastHeartbeat` to the current timestamp
 - Should be called every 30 seconds by hook scripts
-- Sessions without heartbeat for 2+ minutes are marked as 'stale' by the session monitor
+- **Staleness Detection**: Sessions are marked 'stale' by the session monitor when
+  `metadata.lastHeartbeat` (parsed as timestamptz) is older than 2 minutes. If
+  `lastHeartbeat` is missing or invalid, `updated_at` is used as a fallback.
+- Note: The session monitor checks `metadata.lastHeartbeat` specifically to avoid
+  false positives from unrelated updates that might touch `updated_at`
 
 ---
 

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -815,7 +815,10 @@ Claude Code provides these variables to hooks:
 The session monitor is a background service that detects stale and crashed sessions:
 
 **Stale Detection** (every minute):
-- Queries for active sessions with `updated_at` older than 2 minutes
+- Queries for active sessions where `metadata.lastHeartbeat` (parsed as timestamptz) is older than 2 minutes
+- Falls back to `updated_at` when `metadata.lastHeartbeat` is missing or unparseable
+- The heartbeat endpoint **must** set `metadata.lastHeartbeat` so the monitor uses it preferentially
+- This avoids false positives from unrelated updates that might touch `updated_at`
 - Marks sessions as 'stale' status
 - Triggers session state change metrics
 

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -487,6 +487,35 @@ HTTP/1.1 200 OK
 Content-Length: 0
 ```
 
+#### 10. Session Heartbeat
+
+**Purpose**: Indicate session liveness. Called periodically by hook scripts to prevent session from being marked as stale.
+
+**Request**:
+```http
+POST /api/sessions/:id/heartbeat
+```
+
+**Response** (200 OK):
+```json
+{
+  "status": "ok"
+}
+```
+
+**Error Response** (404 Not Found):
+```json
+{
+  "error": "Session not found",
+  "code": "SESSION_NOT_FOUND"
+}
+```
+
+**Implementation Notes**:
+- Updates both `updated_at` and stores `lastHeartbeat` timestamp in session metadata
+- Should be called every 30 seconds by hook scripts
+- Sessions without heartbeat for 2+ minutes are marked as 'stale' by the session monitor
+
 ---
 
 ## Database Design
@@ -503,7 +532,7 @@ CREATE TABLE sessions (
     claude_session_id VARCHAR(255),
     project_path VARCHAR(500) NOT NULL,
     project_type VARCHAR(50) NOT NULL CHECK (project_type IN ('local', 'github', 'e2b', 'worktree')),
-    status VARCHAR(50) DEFAULT 'active' CHECK (status IN ('active', 'paused', 'completed', 'error')),
+    status VARCHAR(50) DEFAULT 'active' CHECK (status IN ('active', 'paused', 'completed', 'error', 'stale', 'crashed')),
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW(),
     version INTEGER NOT NULL DEFAULT 1,  -- Optimistic locking version
@@ -766,6 +795,40 @@ Claude Code provides these variables to hooks:
 | `TOOL_INPUT` | JSON | `{"command":"ls"}` | Tool input parameters |
 | `TOOL_RESULT` | string | `"file1.txt\nfile2.txt"` | Tool output (may be very large) |
 | `MESSAGE` | string | `"Task completed"` | Notification message |
+
+**Additional orchestrator environment variables**:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ORCHESTRATOR_SESSION_ID` | UUID | - | Orchestrator session UUID (enables heartbeat) |
+| `HEARTBEAT_INTERVAL` | integer | 30 | Heartbeat interval in seconds |
+| `CLAUDE_ORCHESTRATOR_API` | URL | `http://localhost:3001` | Orchestrator API endpoint |
+| `CLAUDE_HOOK_SECRET` | string | - | Optional shared secret for authentication |
+
+### Session Monitor
+
+The session monitor is a background service that detects stale and crashed sessions:
+
+**Stale Detection** (every minute):
+- Queries for active sessions with `updated_at` older than 2 minutes
+- Marks sessions as 'stale' status
+- Triggers session state change metrics
+
+**Process Liveness Check** (every 5 minutes):
+- Queries sessions with `claudePid` in metadata
+- Checks if the PID is still alive using signal 0
+- Marks sessions with dead processes as 'crashed' status
+
+**Configuration Environment Variables**:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ENABLE_SESSION_MONITOR` | boolean | true | Enable/disable session monitor |
+| `SESSION_STALE_TIMEOUT_MINUTES` | integer | 2 | Minutes before marking session stale |
+| `SESSION_STALE_CRON` | cron | `* * * * *` | Cron expression for stale detection |
+| `SESSION_LIVENESS_CRON` | cron | `*/5 * * * *` | Cron expression for liveness checks |
+| `ENABLE_STALE_DETECTION` | boolean | true | Enable stale session detection |
+| `ENABLE_LIVENESS_CHECK` | boolean | true | Enable PID liveness checking |
 
 ---
 

--- a/hooks/claude-orchestrator-cleanup.sh
+++ b/hooks/claude-orchestrator-cleanup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Claude Orchestrator - Cleanup Hook
+#
+# This script is called when a Claude Code session ends.
+# It stops the heartbeat process and notifies the orchestrator that the session is complete.
+#
+# IMPORTANT: This script MUST always exit 0 to avoid blocking Claude Code.
+# All errors are handled gracefully and logged.
+#
+# Environment Variables (set by Claude Code):
+#   CLAUDE_SESSION_ID - The Claude Code session identifier
+#
+# Environment Variables (configuration):
+#   CLAUDE_ORCHESTRATOR_API  - API endpoint (default: http://localhost:3001)
+#   CLAUDE_HOOK_SECRET       - Optional shared secret for authentication
+#   ORCHESTRATOR_SESSION_ID  - UUID of the orchestrator session
+
+# Disable strict error mode - we handle errors gracefully to never block Claude Code
+set +e
+
+# Configuration with defaults
+API_URL="${CLAUDE_ORCHESTRATOR_API:-http://localhost:3001}"
+HOOK_SECRET="${CLAUDE_HOOK_SECRET:-}"
+ORCHESTRATOR_SESSION_ID="${ORCHESTRATOR_SESSION_ID:-}"
+
+# Stop the heartbeat background process
+stop_heartbeat() {
+    local session_id="$1"
+
+    if [ -z "$session_id" ]; then
+        return 0
+    fi
+
+    local pid_file="/tmp/claude-heartbeat-${session_id}.pid"
+
+    if [ -f "$pid_file" ]; then
+        local pid
+        pid=$(cat "$pid_file" 2>/dev/null)
+        if [ -n "$pid" ]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+        rm -f "$pid_file" 2>/dev/null
+    fi
+
+    return 0
+}
+
+# Notify the orchestrator that the session is complete
+notify_completion() {
+    local session_id="$1"
+    local status="${2:-completed}"
+
+    if [ -z "$session_id" ]; then
+        return 0
+    fi
+
+    local curl_args=(-sS -X PATCH)
+    curl_args+=(-H "Content-Type: application/json")
+    curl_args+=(--connect-timeout 5)
+    curl_args+=(--max-time 10)
+
+    if [ -n "$HOOK_SECRET" ]; then
+        curl_args+=(-H "x-hook-secret: $HOOK_SECRET")
+    fi
+
+    curl_args+=(-d "{\"status\":\"$status\"}")
+    curl_args+=("$API_URL/api/sessions/$session_id")
+
+    curl "${curl_args[@]}" >/dev/null 2>&1 &
+
+    return 0
+}
+
+# Main execution
+main() {
+    # Stop heartbeat if running
+    if [ -n "$ORCHESTRATOR_SESSION_ID" ]; then
+        stop_heartbeat "$ORCHESTRATOR_SESSION_ID"
+
+        # Notify orchestrator of completion
+        notify_completion "$ORCHESTRATOR_SESSION_ID" "completed"
+    fi
+
+    # Always exit 0 to not block Claude Code
+    exit 0
+}
+
+# Run main function
+main "$@"

--- a/hooks/claude-orchestrator-cleanup.sh
+++ b/hooks/claude-orchestrator-cleanup.sh
@@ -12,7 +12,8 @@
 #
 # Environment Variables (configuration):
 #   CLAUDE_ORCHESTRATOR_API  - API endpoint (default: http://localhost:3001)
-#   CLAUDE_HOOK_SECRET       - Optional shared secret for authentication
+#   CLAUDE_HOOK_SECRET       - Optional shared secret for hook authentication
+#   ORCHESTRATOR_API_KEY     - Optional API key for session endpoint authentication
 #   ORCHESTRATOR_SESSION_ID  - UUID of the orchestrator session
 
 # Disable strict error mode - we handle errors gracefully to never block Claude Code
@@ -21,6 +22,7 @@ set +e
 # Configuration with defaults
 API_URL="${CLAUDE_ORCHESTRATOR_API:-http://localhost:3001}"
 HOOK_SECRET="${CLAUDE_HOOK_SECRET:-}"
+API_KEY="${ORCHESTRATOR_API_KEY:-}"
 ORCHESTRATOR_SESSION_ID="${ORCHESTRATOR_SESSION_ID:-}"
 
 # Stop the heartbeat background process
@@ -61,6 +63,10 @@ notify_completion() {
 
     if [ -n "$HOOK_SECRET" ]; then
         curl_args+=(-H "x-hook-secret: $HOOK_SECRET")
+    fi
+
+    if [ -n "$API_KEY" ]; then
+        curl_args+=(-H "x-api-key: $API_KEY")
     fi
 
     curl_args+=(-d "{\"status\":\"$status\"}")

--- a/hooks/claude-orchestrator-hook.sh
+++ b/hooks/claude-orchestrator-hook.sh
@@ -16,7 +16,8 @@
 # Environment Variables (configuration):
 #   CLAUDE_ORCHESTRATOR_API  - API endpoint (default: http://localhost:3001)
 #   CLAUDE_ORCHESTRATOR_LOGS - Log directory (default: /var/log/claude-orchestrator/events)
-#   CLAUDE_HOOK_SECRET       - Optional shared secret for authentication
+#   CLAUDE_HOOK_SECRET       - Optional shared secret for hook authentication
+#   ORCHESTRATOR_API_KEY     - Optional API key for session endpoint authentication
 #   HOOK_TIMEOUT             - HTTP timeout in seconds (default: 5)
 #   ORCHESTRATOR_SESSION_ID  - UUID of the orchestrator session (enables heartbeat)
 #   HEARTBEAT_INTERVAL       - Heartbeat interval in seconds (default: 30)
@@ -28,6 +29,7 @@ set +e
 API_URL="${CLAUDE_ORCHESTRATOR_API:-http://localhost:3001}"
 LOG_DIR="${CLAUDE_ORCHESTRATOR_LOGS:-/var/log/claude-orchestrator/events}"
 HOOK_SECRET="${CLAUDE_HOOK_SECRET:-}"
+API_KEY="${ORCHESTRATOR_API_KEY:-}"
 TIMEOUT="${HOOK_TIMEOUT:-5}"
 MAX_RESULT_SIZE=50000
 
@@ -123,6 +125,10 @@ send_heartbeat() {
 
     if [ -n "$HOOK_SECRET" ]; then
         curl_args+=(-H "x-hook-secret: $HOOK_SECRET")
+    fi
+
+    if [ -n "$API_KEY" ]; then
+        curl_args+=(-H "x-api-key: $API_KEY")
     fi
 
     curl "${curl_args[@]}" "$API_URL/api/sessions/$session_id/heartbeat" >/dev/null 2>&1

--- a/hooks/claude-orchestrator-hook.sh
+++ b/hooks/claude-orchestrator-hook.sh
@@ -131,7 +131,7 @@ send_heartbeat() {
         curl_args+=(-H "x-api-key: $API_KEY")
     fi
 
-    curl "${curl_args[@]}" "$API_URL/api/sessions/$session_id/heartbeat" >/dev/null 2>&1
+    curl "${curl_args[@]}" "$API_URL/api/hooks/sessions/$session_id/heartbeat" >/dev/null 2>&1
     return $?
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "jest": "^30.2.0",
         "supertest": "^7.1.4",
         "ts-jest": "^29.4.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,6 +1,7 @@
 // src/api/hooks.ts
-import express, { RequestHandler } from 'express';
+import express, { Request, Response, RequestHandler } from 'express';
 import { Pool } from 'pg';
+import rateLimit from 'express-rate-limit';
 import { createLogger } from '../utils/logger';
 import { validate as uuidValidate } from 'uuid';
 import {
@@ -10,7 +11,7 @@ import {
 } from '../db/queries';
 import { withOptimisticLockRetry, retryMetrics } from '../db/retry';
 import { scrubSecrets, scrubObjectSecrets, logScrubbedSecrets, isScrubbingEnabled } from '../services/secretScrubber';
-import { hooksReceivedTotal, hookDeliveryLatency } from '../metrics';
+import { hooksReceivedTotal, hookDeliveryLatency, heartbeatRequestsTotal } from '../metrics';
 
 /**
  * Options for configuring the hook router
@@ -25,6 +26,34 @@ export interface HookRouterOptions {
 }
 
 const logger = createLogger('hooks');
+
+/**
+ * Rate limiter for heartbeat endpoint
+ * Heartbeats should be sent every 30 seconds, so we allow 10 per minute per session
+ * with a short window to handle burst reconnects
+ */
+const heartbeatRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // 10 requests per minute per session
+  keyGenerator: (req: Request) => {
+    // Use session ID as key to rate limit per session, not per IP
+    return req.params.id || req.ip || 'unknown';
+  },
+  message: { error: 'Too many heartbeat requests', code: 'RATE_LIMITED' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req: Request, res: Response) => {
+    logger.warn('Heartbeat rate limit exceeded', {
+      sessionId: req.params.id,
+      ip: req.ip,
+    });
+    heartbeatRequestsTotal.labels({ status: 'rate_limited' }).inc();
+    res.status(429).json({
+      error: 'Too many heartbeat requests',
+      code: 'RATE_LIMITED'
+    });
+  },
+});
 
 /**
  * Validate that a string is a valid UUID v4
@@ -531,7 +560,8 @@ export function createHookRouter(db: Pool, options: HookRouterOptions = {}) {
 
   // Session heartbeat endpoint - called periodically by hook scripts to indicate liveness
   // This endpoint is accessible via hook auth (x-hook-secret) for Claude Code hooks
-  router.post('/sessions/:id/heartbeat', async (req, res) => {
+  // Rate limited to prevent abuse (10 requests per minute per session)
+  router.post('/sessions/:id/heartbeat', heartbeatRateLimiter, async (req, res) => {
     try {
       const sessionId = req.params.id;
 
@@ -540,6 +570,7 @@ export function createHookRouter(db: Pool, options: HookRouterOptions = {}) {
         logger.warn('Heartbeat received with invalid session ID format', {
           sessionId,
         });
+        heartbeatRequestsTotal.labels({ status: 'invalid_id' }).inc();
         res.status(400).json({
           error: 'Invalid session ID format',
           code: 'INVALID_SESSION_ID'
@@ -554,6 +585,7 @@ export function createHookRouter(db: Pool, options: HookRouterOptions = {}) {
         logger.warn('Heartbeat received for unknown session', {
           sessionId,
         });
+        heartbeatRequestsTotal.labels({ status: 'not_found' }).inc();
         res.status(404).json({
           error: 'Session not found',
           code: 'SESSION_NOT_FOUND'
@@ -563,12 +595,14 @@ export function createHookRouter(db: Pool, options: HookRouterOptions = {}) {
 
       // Heartbeats are frequent - only log at debug level in production
       // For now, we'll skip logging to reduce noise
+      heartbeatRequestsTotal.labels({ status: 'success' }).inc();
       res.status(200).json({ status: 'ok' });
     } catch (error) {
       logger.error('Heartbeat processing error', {
         sessionId: req.params.id,
         error: (error as Error).message,
       });
+      heartbeatRequestsTotal.labels({ status: 'error' }).inc();
       res.status(500).json({
         error: 'Internal server error',
         code: 'HEARTBEAT_ERROR'

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -200,7 +200,8 @@ export const sessionMonitorErrors = new Counter({
 });
 
 /**
- * Gauge for heartbeat endpoint requests
+ * Counter for heartbeat endpoint requests
+ * Labels: status ('success', 'not_found', 'error')
  */
 export const heartbeatRequestsTotal = new Counter({
   name: 'heartbeat_requests_total',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -154,3 +154,57 @@ export const hookDeliveryLatency = new Histogram({
   buckets: [50, 100, 250, 500, 1000, 2500, 5000, 10000],
   registers: [register],
 });
+
+// =============================================================================
+// Session Monitor Metrics
+// =============================================================================
+
+/**
+ * Counter for sessions marked as stale
+ */
+export const sessionsMarkedStale = new Counter({
+  name: 'sessions_marked_stale_total',
+  help: 'Total number of sessions marked as stale due to heartbeat timeout',
+  registers: [register],
+});
+
+/**
+ * Counter for sessions marked as crashed
+ */
+export const sessionsMarkedCrashed = new Counter({
+  name: 'sessions_marked_crashed_total',
+  help: 'Total number of sessions marked as crashed due to PID check failure',
+  registers: [register],
+});
+
+/**
+ * Counter for session monitor runs
+ * Labels: type ('stale', 'liveness')
+ */
+export const sessionMonitorRuns = new Counter({
+  name: 'session_monitor_runs_total',
+  help: 'Total number of session monitor check runs',
+  labelNames: ['type'] as const,
+  registers: [register],
+});
+
+/**
+ * Counter for session monitor errors
+ * Labels: type ('stale', 'liveness')
+ */
+export const sessionMonitorErrors = new Counter({
+  name: 'session_monitor_errors_total',
+  help: 'Total number of errors in session monitor',
+  labelNames: ['type'] as const,
+  registers: [register],
+});
+
+/**
+ * Gauge for heartbeat endpoint requests
+ */
+export const heartbeatRequestsTotal = new Counter({
+  name: 'heartbeat_requests_total',
+  help: 'Total number of heartbeat requests received',
+  labelNames: ['status'] as const,
+  registers: [register],
+});

--- a/src/services/sessionMonitor.ts
+++ b/src/services/sessionMonitor.ts
@@ -1,0 +1,343 @@
+/**
+ * Session Monitor Service
+ *
+ * Provides automatic detection of stale and crashed sessions using node-cron
+ * for scheduling. Handles:
+ * - Stale session detection (no heartbeat for configurable timeout)
+ * - Process liveness checks via PID tracking
+ * - Session status updates with metrics tracking
+ *
+ * @module services/sessionMonitor
+ */
+
+import cron, { ScheduledTask } from 'node-cron';
+import { Pool } from 'pg';
+import {
+  getInactiveSessions,
+  getSessionsWithPid,
+  batchUpdateSessionStatus,
+  SessionStatus,
+} from '../db/queries';
+import { createLogger } from '../utils/logger';
+import {
+  sessionsMarkedStale,
+  sessionsMarkedCrashed,
+  sessionMonitorRuns,
+  sessionMonitorErrors,
+} from '../metrics';
+
+const logger = createLogger('session-monitor');
+
+/**
+ * Configuration for the session monitor
+ */
+export interface SessionMonitorConfig {
+  /** Minutes of inactivity before marking a session as stale (default: 2) */
+  staleTimeoutMinutes: number;
+  /** Cron expression for stale session detection (default: every minute) */
+  staleCronExpression: string;
+  /** Cron expression for PID liveness check (default: every 5 minutes) */
+  livenessCronExpression: string;
+  /** Enable stale session detection (default: true) */
+  enableStaleDetection: boolean;
+  /** Enable PID liveness checks (default: true) */
+  enableLivenessCheck: boolean;
+}
+
+/**
+ * Get session monitor configuration from environment variables
+ */
+export function getSessionMonitorConfig(): SessionMonitorConfig {
+  return {
+    staleTimeoutMinutes: parseInt(process.env.SESSION_STALE_TIMEOUT_MINUTES || '2', 10),
+    staleCronExpression: process.env.SESSION_STALE_CRON || '* * * * *',
+    livenessCronExpression: process.env.SESSION_LIVENESS_CRON || '*/5 * * * *',
+    enableStaleDetection: process.env.ENABLE_STALE_DETECTION !== 'false',
+    enableLivenessCheck: process.env.ENABLE_LIVENESS_CHECK !== 'false',
+  };
+}
+
+/**
+ * Session monitor statistics
+ */
+export interface SessionMonitorStats {
+  /** Number of sessions marked as stale */
+  sessionsMarkedStale: number;
+  /** Number of sessions marked as crashed */
+  sessionsMarkedCrashed: number;
+  /** Total number of monitor runs */
+  totalRuns: number;
+  /** Number of errors encountered */
+  errors: number;
+  /** Timestamp of last stale check */
+  lastStaleCheck: Date | null;
+  /** Timestamp of last liveness check */
+  lastLivenessCheck: Date | null;
+  /** Whether the monitor is running */
+  isRunning: boolean;
+}
+
+/**
+ * Check if a process with the given PID is alive
+ * Uses signal 0 to check process existence without killing it
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 checks if the process exists without sending a real signal
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    // ESRCH = No such process
+    // EPERM = Process exists but we don't have permission (still alive)
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'EPERM') {
+      return true; // Process exists but we can't signal it
+    }
+    return false; // Process doesn't exist
+  }
+}
+
+/**
+ * SessionMonitor class manages the scheduled monitoring of session health
+ */
+export class SessionMonitor {
+  private staleTask: ScheduledTask | null = null;
+  private livenessTask: ScheduledTask | null = null;
+  private db: Pool;
+  private config: SessionMonitorConfig;
+  private stats: SessionMonitorStats = {
+    sessionsMarkedStale: 0,
+    sessionsMarkedCrashed: 0,
+    totalRuns: 0,
+    errors: 0,
+    lastStaleCheck: null,
+    lastLivenessCheck: null,
+    isRunning: false,
+  };
+
+  constructor(db: Pool, config?: Partial<SessionMonitorConfig>) {
+    this.db = db;
+    this.config = { ...getSessionMonitorConfig(), ...config };
+  }
+
+  /**
+   * Start the session monitor
+   */
+  start(): void {
+    if (this.stats.isRunning) {
+      logger.warn('Session monitor already running');
+      return;
+    }
+
+    // Start stale session detection
+    if (this.config.enableStaleDetection) {
+      this.staleTask = cron.schedule(this.config.staleCronExpression, async () => {
+        await this.checkStaleSessions();
+      });
+      logger.info('Stale session detection started', {
+        cronExpression: this.config.staleCronExpression,
+        timeoutMinutes: this.config.staleTimeoutMinutes,
+      });
+    }
+
+    // Start PID liveness checks
+    if (this.config.enableLivenessCheck) {
+      this.livenessTask = cron.schedule(this.config.livenessCronExpression, async () => {
+        await this.checkProcessLiveness();
+      });
+      logger.info('Process liveness check started', {
+        cronExpression: this.config.livenessCronExpression,
+      });
+    }
+
+    this.stats.isRunning = true;
+    logger.info('Session monitor started', {
+      staleDetection: this.config.enableStaleDetection,
+      livenessCheck: this.config.enableLivenessCheck,
+    });
+  }
+
+  /**
+   * Stop the session monitor
+   */
+  stop(): void {
+    if (this.staleTask) {
+      this.staleTask.stop();
+      this.staleTask = null;
+    }
+
+    if (this.livenessTask) {
+      this.livenessTask.stop();
+      this.livenessTask = null;
+    }
+
+    this.stats.isRunning = false;
+    logger.info('Session monitor stopped');
+  }
+
+  /**
+   * Get monitor statistics
+   */
+  getStats(): SessionMonitorStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * Check for and mark stale sessions
+   */
+  async checkStaleSessions(): Promise<number> {
+    this.stats.totalRuns++;
+    this.stats.lastStaleCheck = new Date();
+    sessionMonitorRuns.labels({ type: 'stale' }).inc();
+
+    try {
+      // Get active sessions that haven't been updated within the timeout
+      const staleSessions = await getInactiveSessions(
+        this.db,
+        this.config.staleTimeoutMinutes,
+        100
+      );
+
+      if (staleSessions.length === 0) {
+        return 0;
+      }
+
+      const sessionIds = staleSessions.map(s => s.id);
+      const updated = await batchUpdateSessionStatus(this.db, sessionIds, 'stale');
+
+      this.stats.sessionsMarkedStale += updated;
+      sessionsMarkedStale.inc(updated);
+
+      logger.info('Sessions marked as stale', {
+        count: updated,
+        sessionIds,
+        timeoutMinutes: this.config.staleTimeoutMinutes,
+      });
+
+      return updated;
+    } catch (error) {
+      this.stats.errors++;
+      sessionMonitorErrors.labels({ type: 'stale' }).inc();
+      logger.error('Stale session detection failed', {
+        error: (error as Error).message,
+        stack: (error as Error).stack,
+      });
+      return 0;
+    }
+  }
+
+  /**
+   * Check process liveness for sessions with tracked PIDs
+   */
+  async checkProcessLiveness(): Promise<number> {
+    this.stats.totalRuns++;
+    this.stats.lastLivenessCheck = new Date();
+    sessionMonitorRuns.labels({ type: 'liveness' }).inc();
+
+    try {
+      // Get active sessions with claudePid in metadata
+      const sessions = await getSessionsWithPid(this.db);
+
+      if (sessions.length === 0) {
+        return 0;
+      }
+
+      const crashedSessionIds: string[] = [];
+
+      for (const session of sessions) {
+        const pid = session.metadata?.claudePid;
+
+        // Validate PID is a reasonable number
+        if (typeof pid !== 'number' || pid <= 0 || !Number.isInteger(pid)) {
+          logger.warn('Invalid PID in session metadata', {
+            sessionId: session.id,
+            pid,
+          });
+          continue;
+        }
+
+        if (!isProcessAlive(pid)) {
+          crashedSessionIds.push(session.id);
+          logger.info('Process not found for session', {
+            sessionId: session.id,
+            pid,
+          });
+        }
+      }
+
+      if (crashedSessionIds.length === 0) {
+        return 0;
+      }
+
+      const updated = await batchUpdateSessionStatus(this.db, crashedSessionIds, 'crashed');
+
+      this.stats.sessionsMarkedCrashed += updated;
+      sessionsMarkedCrashed.inc(updated);
+
+      logger.info('Sessions marked as crashed', {
+        count: updated,
+        sessionIds: crashedSessionIds,
+      });
+
+      return updated;
+    } catch (error) {
+      this.stats.errors++;
+      sessionMonitorErrors.labels({ type: 'liveness' }).inc();
+      logger.error('Process liveness check failed', {
+        error: (error as Error).message,
+        stack: (error as Error).stack,
+      });
+      return 0;
+    }
+  }
+
+  /**
+   * Run both checks manually (useful for testing)
+   */
+  async runChecks(): Promise<{ stale: number; crashed: number }> {
+    const stale = await this.checkStaleSessions();
+    const crashed = await this.checkProcessLiveness();
+    return { stale, crashed };
+  }
+}
+
+// Singleton instance
+let sessionMonitorInstance: SessionMonitor | null = null;
+
+/**
+ * Start the session monitor daemon
+ *
+ * @param db Database pool
+ * @param config Optional configuration overrides
+ */
+export function startSessionMonitor(
+  db: Pool,
+  config?: Partial<SessionMonitorConfig>
+): SessionMonitor {
+  if (sessionMonitorInstance) {
+    logger.warn('Session monitor already exists, returning existing instance');
+    return sessionMonitorInstance;
+  }
+
+  sessionMonitorInstance = new SessionMonitor(db, config);
+  sessionMonitorInstance.start();
+
+  return sessionMonitorInstance;
+}
+
+/**
+ * Stop the session monitor daemon
+ */
+export function stopSessionMonitor(): void {
+  if (sessionMonitorInstance) {
+    sessionMonitorInstance.stop();
+    sessionMonitorInstance = null;
+  }
+}
+
+/**
+ * Get the session monitor instance
+ */
+export function getSessionMonitor(): SessionMonitor | null {
+  return sessionMonitorInstance;
+}


### PR DESCRIPTION
Implement multi-layered session health monitoring:

- Add heartbeat endpoint (POST /api/sessions/:id/heartbeat) for session liveness signaling
- Create sessionMonitor.ts service with scheduled jobs:
  - Stale session detection (marks sessions without heartbeat as 'stale')
  - Process liveness checks via PID tracking (marks dead processes as 'crashed')
- Add 'crashed' status to SessionStatus type
- Update PATCH endpoint to support metadata merging (for claudePid tracking)
- Extend hook scripts with background heartbeat process
- Add cleanup hook script for session completion
- Add Prometheus metrics for session monitor operations
- Update documentation with new configuration options

Configuration via environment variables:
- ENABLE_SESSION_MONITOR (default: true)
- SESSION_STALE_TIMEOUT_MINUTES (default: 2)
- SESSION_STALE_CRON (default: * * * * *)
- SESSION_LIVENESS_CRON (default: */5 * * * *)


Addressed Issue #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session heartbeat endpoints (API and hook), per-session rate limiting, metadata-merged PATCH updates, and automatic session monitoring that marks sessions "stale" or "crashed" and exposes monitor stats/metrics in health checks.
* **Documentation**
  * Updated docs for heartbeat workflow, authentication for session and hook endpoints, new session states, and monitoring/orchestrator configuration environment options.
* **Chores**
  * Added orchestrator hook scripts to manage heartbeats and notify session completion; added monitoring metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->